### PR TITLE
Fix Scoop installation

### DIFF
--- a/run_mkdocs_required_app_install.bat
+++ b/run_mkdocs_required_app_install.bat
@@ -9,7 +9,7 @@ Powershell.exe choco install rsvg-convert
 Powershell.exe choco install python
 Powershell.exe choco install miktex
 
-Powershell.exe Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh')
+Powershell.exe iex \"& {$(irm get.scoop.sh)} -RunAsAdmin\"
 Powershell.exe Set-ExecutionPolicy RemoteSigned -scope CurrentUser
 Powershell.exe scoop install curl
 Powershell.exe scoop install marp


### PR DESCRIPTION
* Done by aligning installation command with newer one. Also fixed syntaxing for PowerShell.

TODO: Also restart terminal after installing package managers.

Signed-off-by: Bedirhan KURT <bedirhan.kurt.trjp@gmail.com>